### PR TITLE
[3rdparty/qpOASES/CMakeLists.txt] add options for downloading qpOASES

### DIFF
--- a/3rdparty/qpOASES/CMakeLists.txt
+++ b/3rdparty/qpOASES/CMakeLists.txt
@@ -1,7 +1,11 @@
 message("This is qpOASES")
 
+option(TRUST_QPOASES_SERVER_CERT "trust certification of https://projects.coin-or.org/svn/qpOASES/stable/3.0" ON)
+if (${TRUST_QPOASES_SERVER_CERT})
+  set(TRUST_SERVER_CERT --trust-server-cert)
+endif()
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
-  execute_process(COMMAND svn co https://projects.coin-or.org/svn/qpOASES/stable/3.0 ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
+  execute_process(COMMAND svn co ${TRUST_SERVER_CERT} --non-interactive https://projects.coin-or.org/svn/qpOASES/stable/3.0 ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
   execute_process(COMMAND sed -i -e "s/qpOASES\ STATIC/qpOASES\ SHARED/g" ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0/CMakeLists.txt)
   execute_process(COMMAND cmake -E chdir ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0 make)
 endif()


### PR DESCRIPTION
https://github.com/kindsenior/jsk_choreonoid/blob/master/3rdparty/qpOASES/CMakeLists.txt#L4 が、証明書の手動認証モードに入って失敗するので、ダウンロード元の証明書を信頼するようにCMakeのオプションを追加しました。
デフォルトでON(証明書を信頼する)になっています。
