### PR TITLE
[plugins/SlideFrictionControlPlugin/SlideFrictionControl.h] include UtilPlugin.h

### DIFF
--- a/plugins/SlideFrictionControlPlugin/SlideFrictionControl.h
+++ b/plugins/SlideFrictionControlPlugin/SlideFrictionControl.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <MultiContactStabilizerPlugin/ModelPredictiveController.h>
+#include <UtilPlugin/UtilPlugin.h>
 
 namespace hrp {
 


### PR DESCRIPTION
masterのビルドに失敗するのですが、ここでインクルードして良いでしょうか？
