### PR TITLE
[.gitignore] ignore python Byte-compiled / optimized / DLL files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@
 *.optionaldata
 *.gsens
 *.wrenches
+
+# python
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
.pyc等のファイルを無視するようにしました.