### PR TITLE
BodyUtilPlugin でのnamespaceについて

### DIFF
--- a/plugins/BodyUtilPlugin/python/PyTypesPlugin.cpp
+++ b/plugins/BodyUtilPlugin/python/PyTypesPlugin.cpp
@@ -9,7 +9,6 @@
 #include <boost/foreach.hpp>
 #include <boost/range/value_type.hpp>
 
-namespace python = boost::python;
 using namespace cnoid;
 
 namespace {


### PR DESCRIPTION
自分もあまり詳しく調べてないですが，最近workspaceの構成を変えたせいかもしれませんが，
該当行を削除しないとビルドが通りませんでした

基本的にPyTypesPlugin.cppのpython::hogeとかなっている場所で
```
reference to python is ambiguous
choreonoid-1.6/cnoid/src/Util/boostpython/PyUtil.h:15:18: note: candidates are: namespace cnoid::python
```
となっていて
```
namespace python = boost::python;
```
を挿入したせいで
python -> boost::python
と
python -> cnoid::python
の両方が見えてエラーになっている感じだと思います

ちゃんと調べてないですが，choreonoidの更新とかでしょうか？

@Tnoriaki はどうでしょうか？


